### PR TITLE
add warning that this pkg uses UC pre-releases

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = ungoogled-chromium-xdg-bin
-	pkgdesc = A lightweight approach to removing Google web service dependency - without creating a useless ~/.pki directory (binary version)
+	pkgdesc = A lightweight approach to removing Google web service dependency - without creating a useless ~/.pki directory (using pre-releases), (binary version)
 	pkgver = 122.0.6261.128
 	pkgrel = 1
 	url = https://github.com/Eloston/ungoogled-chromium

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 pkgname=ungoogled-chromium-xdg-bin
 pkgver=122.0.6261.128
 pkgrel=1
-pkgdesc="A lightweight approach to removing Google web service dependency - without creating a useless ~/.pki directory (binary version)"
+pkgdesc="A lightweight approach to removing Google web service dependency - without creating a useless ~/.pki directory (using pre-releases), (binary version)"
 arch=('x86_64')
 url="https://github.com/Eloston/ungoogled-chromium"
 license=('BSD')


### PR DESCRIPTION
Proposing a solution for [this issue](https://github.com/noahvogt/ungoogled-chromium-xdg-aur/issues/7).